### PR TITLE
Remove all null characters when quoting

### DIFF
--- a/Doctrine/DBAL/Driver/PDODblib/Connection.php
+++ b/Doctrine/DBAL/Driver/PDODblib/Connection.php
@@ -37,11 +37,7 @@ class Connection extends \Doctrine\DBAL\Driver\PDOConnection implements \Doctrin
         $val = parent::quote($value, $type);
 
         // Fix for a driver version terminating all values with null byte
-        if (strpos($val, "\0") !== false) {
-            $val = substr($val, 0, -1);
-        }
-
-        return $val;
+        return str_replace(chr(0), '', $val);
     }
 
     /**


### PR DESCRIPTION
Previous code only removes a null character from the end of a string (although the code doesn't work for me), while sending a null character at any position will brake a query. 
