### PR TITLE
replace unsupported ucs-2 characters in a string with �

### DIFF
--- a/Doctrine/DBAL/Driver/PDODblib/Connection.php
+++ b/Doctrine/DBAL/Driver/PDODblib/Connection.php
@@ -38,8 +38,20 @@ class Connection extends \Doctrine\DBAL\Driver\PDOConnection implements \Doctrin
 
         // Fix for a driver version terminating all values with null byte
         $val = rtrim($val, "\0");
+        
+        // Freetds communicates with the server using UCS-2 (since v7.0).
+        // Freetds claims to convert from any given client charset to UCS-2 using iconv. Which should strip or replace unsupported chars. 
+        // However in my experience, characters like 👍 (THUMBS UP SIGN, \u1F44D) end up in MSSQL shouting 'incorrect syntax' still.
+        $val = static::replaceNonUcs2Chars($val);
 
         return $val;
+    }
+    
+    public static function replaceNonUcs2Chars($val)
+    {
+        // UCS-2 cannot represent unicode code points outside the BMP. (> 16 bits.)
+        // Replace those chars with the REPLACEMENT CHARACTER.
+        return preg_replace('/[^\x{0}-x{FFFF}]/u', "\xFFFD", $val);
     }
 
     /**


### PR DESCRIPTION
Freetds communicates with the server using UCS-2 (since v7.0). Freetds claims to convert from any given client charset to UCS-2 using iconv. Which should strip or replace unsupported chars. However in my experience, characters like 👍 (THUMBS UP SIGN, \u1F44D) end up in MSSQL shouting 'incorrect syntax' still.

So I've made this patch to replace any characters unsupported by UCS-2 beforehand, at the moment of quoting the string.