### PR TITLE
Add version and appname config

### DIFF
--- a/Doctrine/DBAL/Driver/PDODblib/Driver.php
+++ b/Doctrine/DBAL/Driver/PDODblib/Driver.php
@@ -61,6 +61,14 @@ class Driver implements \Doctrine\DBAL\Driver {
             $dsn .= ';charset=' . $params['charset'];
         }
 
+        if (isset($params['version'])) {
+            $dsn .= ';version=' . $params['version'];
+        }
+
+        if (isset($params['appname'])) {
+            $dsn .= ';appname=' . $params['appname'];
+        }
+
         return $dsn;
     }
 


### PR DESCRIPTION
Add support for two configuration keys:
 - appname, a documented component in DSN (http://php.net/manual/en/ref.pdo-dblib.connection.php).
 - version, not documented, but explained in comments (http://php.net/manual/en/ref.pdo-dblib.connection.php#118644).
With this addition, editing freetds.conf to setup tds version should not be a requirement.