### PR TITLE
Allow version to be passed as parameter to DSN

### DIFF
--- a/Doctrine/DBAL/Driver/PDODblib/Driver.php
+++ b/Doctrine/DBAL/Driver/PDODblib/Driver.php
@@ -61,6 +61,10 @@ class Driver implements \Doctrine\DBAL\Driver {
             $dsn .= ';charset=' . $params['charset'];
         }
 
+        if (isset($params['version'])) {
+            $dsn .= ';version=' . $params['version'];
+        }
+
         return $dsn;
     }
 


### PR DESCRIPTION
This patch allow the version to be passed as parameter to the DSN string via config as suggested here: http://php.net/manual/de/ref.pdo-dblib.connection.php#118644

When I set version=8.0 this fixes some Unicode errors and should be very useful for users of this library.