### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ final class DriverManager
 {
     private static $_driverMap = array(
 		/* ... snip ... */
-        'pdo_dblib' => 'Doctrine\DBAL\Driver\PDODblib\Driver',
+        'pdo_dblib'          => 'Lsw\DoctrinePdoDblib\Doctrine\DBAL\Driver\PDODblib\Driver',
     );
 }
 ```


### PR DESCRIPTION
Change the line to add in the paragraph about "Doctrine Test Suite" :

If an user add the line  :
    'pdo_dblib' => 'Doctrine\DBAL\Driver\PDODblib\Driver',

He will have the flollowing error : 
    Attempted to load class "Driver" from namespace "Doctrine\DBAL\Driver\PDODblib".